### PR TITLE
Change heading level for headline

### DIFF
--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -1,7 +1,7 @@
 {% if page.title or page.tag %}
     <div class="breadcrumbs margin-bottom-10">
         <div class="container">
-            <h2 class="pull-left">{% if page.tag %}{{ page.tag }} {% else %}{{ page.title }}{% endif %}</h2>
+            <h1 class="pull-left">{% if page.tag %}{{ page.tag }} {% else %}{{ page.title }}{% endif %}</h1>
             <ul class="pull-right breadcrumb">
                 <li><a href="/">Home</a></li>
                 {% if page.group and page.title != page.group.title %}


### PR DESCRIPTION
Unify template has a SEO design flaw - it uses h2 heading for the top headline for all inner pages at the breadcrumbs. Each page should have one h1 headline, according to SEO best practices, so I changed h2 to h1. Further headings hierarchy of particular inner pages should be examined (h1 should be followed by h2, h3 etc.).
